### PR TITLE
Handle camera read failure recovery

### DIFF
--- a/19OK.py
+++ b/19OK.py
@@ -189,7 +189,6 @@ class TcpSender:
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             self.sock.connect((self.host, self.port))
-            print(f"[TCP] 已连接 {self.host}:{self.port}")
         except Exception as e:
             self.sock.close()
             print("[TCP] 连接失败:", e)
@@ -222,8 +221,6 @@ class TcpSender:
                             text = seg.decode("utf-8", errors="ignore")
                             if self.on_recv:
                                 self.on_recv(text)
-                            else:
-                                print("[TCP] 收到:", text)
                             buf = buf[i + 1:]
                             i = -1
                     i += 1
@@ -234,7 +231,6 @@ class TcpSender:
     def send_data(self, msg: str):
         try:
             self.sock.sendall(msg.encode("utf-8") + b"\n")
-            print("[TCP] 已发送:", msg)
         except Exception as e:
             print("[TCP] 发送失败:", e)
 
@@ -320,25 +316,10 @@ def detect_shapes(frame_bgr: np.ndarray,
             labels.append((label_txt, text_pos, qcolor))
     return labels
 
-class QTextEditLogger(QtCore.QObject):
-    append_text = QtCore.pyqtSignal(str)
-
-    def __init__(self, widget):
-        super().__init__()
-        self.widget = widget
-        self.append_text.connect(self.widget.append)
-
-    def write(self, msg):
-        if msg.strip():   # 避免空行
-            self.append_text.emit(msg.strip())
-
-    def flush(self):
-        pass
-
 # 主窗口
 class MainWindow(QtWidgets.QWidget):
     FPS_CALC_INTERVAL = 30
-    READ_FAIL_THRESHOLD = 30
+    READ_FAIL_THRESHOLD = 60
     tcp_msg_sig = QtCore.pyqtSignal(str)
 
     def __init__(self, colors: List[ColorCfg]):
@@ -359,16 +340,6 @@ class MainWindow(QtWidgets.QWidget):
         self.video_lbl = QtWidgets.QLabel(alignment=QtCore.Qt.AlignCenter)
         self.video_lbl.setMinimumSize(640, 480)
         video_panel.addWidget(self.video_lbl, 1)
-
-        # CMD输出框
-        self.cmd_output = QtWidgets.QTextEdit()
-        self.cmd_output.setReadOnly(True)
-        self.cmd_output.setFixedHeight(150)
-        video_panel.addWidget(self.cmd_output)
-        # 重定向 print 输出到日志框
-        logger = QTextEditLogger(self.cmd_output)
-        sys.stdout = logger
-        sys.stderr = logger
 
         # 把右侧整体加入主布局
         video_container = QtWidgets.QWidget()
@@ -445,7 +416,6 @@ class MainWindow(QtWidgets.QWidget):
             return
         text = json.dumps(obj, ensure_ascii=False)
         self.tcp_sender.send_data(text)
-        self.append_log(f"[发送] {text}")
 
     def send_position_data(self, cam_id: int, detections: list):
         frame = {
@@ -485,14 +455,12 @@ class MainWindow(QtWidgets.QWidget):
                 msg = self.cmd_map[text]
                 if self.tcp_sender:
                     self.tcp_sender.send_data(msg)
-                    self.append_log(f"[发送] {text} -> {msg}")
                 else:
                     print("[TCP] 未连接")
             else:
                 print(f"[未配置] {text}")
 
     def handle_hc_cmd(self, text: str):
-        self.append_log(f"[指令] {text}")
         try:
             cmd = json.loads(text)
         except Exception as e:
@@ -602,11 +570,6 @@ class MainWindow(QtWidgets.QWidget):
             lambda: self.do_capture_and_send(self.cam_combo.currentData() or 0)
         )
         vbox.addStretch(1)
-    def append_log(self, msg: str):
-        if msg.startswith("[发送]") or msg.startswith("[TCP 收到]") or msg.startswith("[测试发送]"):
-            msg = f"<b>{msg}</b>"
-        self.cmd_output.append(msg)
-
     def _add_color_group(self, parent_layout, cfg: ColorCfg):
         # ---------- 1. 可折叠 GroupBox ----------
         gbox = QtWidgets.QGroupBox(cfg.group_title)
@@ -687,7 +650,6 @@ class MainWindow(QtWidgets.QWidget):
         try:
             msg = self.cmd_input.text().format(color="测试色", shape="测试形", area=1234)
             self.tcp_sender.send_data(msg)
-            self.append_log(f"[测试发送] {msg}")
         except Exception as e:
             QtWidgets.QMessageBox.critical(self, "错误", f"发送失败: {e}")
 
@@ -697,7 +659,6 @@ class MainWindow(QtWidgets.QWidget):
     @QtCore.pyqtSlot(str)
     def _process_tcp_msg(self, text: str):
         """Callback for data received from the remote TCP server."""
-        self.append_log(f"[TCP] 收到: {text}")
         try:
             cmd = json.loads(text)
         except Exception as e:
@@ -714,6 +675,10 @@ class MainWindow(QtWidgets.QWidget):
         if self.capture:
             self.capture.release(); self.capture = None
         self.capture = cv2.VideoCapture(idx,cv2.CAP_MSMF)
+        if not self.capture.isOpened():
+            self.capture.release()
+            self.capture = None
+            return
         self.capture.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
         self.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
         self._read_failures = 0
@@ -778,7 +743,6 @@ class MainWindow(QtWidgets.QWidget):
                 if key in self.cmd_map:
                     msg = self.cmd_map[key]
                     self.tcp_sender.send_data(msg)
-                    self.append_log(f"[发送] {key} -> {msg}")
                 else:
                     print(f"[未配置] {key}")
         painter.end()

--- a/19OK.py
+++ b/19OK.py
@@ -341,6 +341,21 @@ class MainWindow(QtWidgets.QWidget):
         self.video_lbl.setMinimumSize(640, 480)
         video_panel.addWidget(self.video_lbl, 1)
 
+        # 识别结果显示框
+        self.msg_frame = QtWidgets.QFrame()
+        self.msg_frame.setFrameStyle(QtWidgets.QFrame.Box | QtWidgets.QFrame.Plain)
+        self.msg_frame.setFixedHeight(40)
+        msg_layout = QtWidgets.QVBoxLayout(self.msg_frame)
+        msg_layout.setContentsMargins(0, 0, 0, 0)
+        self.msg_label = QtWidgets.QLabel()
+        self.msg_label.setAlignment(QtCore.Qt.AlignCenter)
+        msg_layout.addWidget(self.msg_label)
+        video_panel.addWidget(self.msg_frame)
+
+        self.msg_timer = QtCore.QTimer(self)
+        self.msg_timer.setSingleShot(True)
+        self.msg_timer.timeout.connect(lambda: self.msg_label.setText(""))
+
         # 把右侧整体加入主布局
         video_container = QtWidgets.QWidget()
         video_container.setLayout(video_panel)
@@ -427,6 +442,11 @@ class MainWindow(QtWidgets.QWidget):
     def build_model_list_reply(self):
         return {"dsID": "www.hc-system.com.cam", "models": []}
 
+    def _show_detected_labels(self, labels: List[tuple]):
+        text = "\n".join([t for t, _p, _c in labels])
+        self.msg_label.setText(text)
+        self.msg_timer.start(2000)
+
     def do_capture_and_send(self, cam_id: int):
         if not self.capture or not self.capture.isOpened():
             print("[摄像头] 未就绪")
@@ -447,8 +467,9 @@ class MainWindow(QtWidgets.QWidget):
             if chk.isChecked()
         }
         labels = detect_shapes(frame, list(self.colors.values()), shapes_enabled)
-
-        if not labels:
+        if labels:
+            self._show_detected_labels(labels)
+        else:
             print("[识别] 未检测到目标")
         for text, _pos, _col in labels:
             if text in self.cmd_map:
@@ -716,6 +737,8 @@ class MainWindow(QtWidgets.QWidget):
             ("rect",     self.chk_rect)
         ] if chk.isChecked() }
         labels = detect_shapes(frame, list(self.colors.values()), shapes_enabled)
+        if labels:
+            self._show_detected_labels(labels)
         # --- 掩膜窗口更新 ---
         hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
         for cfg in self.colors.values():

--- a/19OK.py
+++ b/19OK.py
@@ -737,8 +737,6 @@ class MainWindow(QtWidgets.QWidget):
             ("rect",     self.chk_rect)
         ] if chk.isChecked() }
         labels = detect_shapes(frame, list(self.colors.values()), shapes_enabled)
-        if labels:
-            self._show_detected_labels(labels)
         # --- 掩膜窗口更新 ---
         hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
         for cfg in self.colors.values():

--- a/19OK.py
+++ b/19OK.py
@@ -338,6 +338,7 @@ class QTextEditLogger(QtCore.QObject):
 # 主窗口
 class MainWindow(QtWidgets.QWidget):
     FPS_CALC_INTERVAL = 30
+    READ_FAIL_THRESHOLD = 30
     tcp_msg_sig = QtCore.pyqtSignal(str)
 
     def __init__(self, colors: List[ColorCfg]):
@@ -379,6 +380,7 @@ class MainWindow(QtWidgets.QWidget):
 
         # 摄像头初始化
         self.capture = None
+        self._read_failures = 0
         self.cam_combo.currentIndexChanged.connect(self.open_camera)
         self.open_camera()
 
@@ -714,6 +716,7 @@ class MainWindow(QtWidgets.QWidget):
         self.capture = cv2.VideoCapture(idx,cv2.CAP_MSMF)
         self.capture.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
         self.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
+        self._read_failures = 0
         self.frame_cnt = 0
         self.last_time = time.time()
         self.fps = 0.0
@@ -731,7 +734,11 @@ class MainWindow(QtWidgets.QWidget):
             return
         ok, frame = self.capture.read()
         if not ok or frame is None or frame.size == 0:
+            self._read_failures += 1
+            if self._read_failures > self.READ_FAIL_THRESHOLD:
+                self.open_camera()
             return
+        self._read_failures = 0
         self.frame_cnt += 1
         if self.frame_cnt % self.FPS_CALC_INTERVAL == 0:
             now = time.time()


### PR DESCRIPTION
## Summary
- Track consecutive camera read failures and reopen capture after repeated errors
- Reset failure counter when camera opens or frames are read successfully

## Testing
- `python -m py_compile 19OK.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689191842a308329830e41bf919ad6d2